### PR TITLE
Add code-server subdomain proxy support

### DIFF
--- a/code-server.subdomain.conf.sample
+++ b/code-server.subdomain.conf.sample
@@ -39,3 +39,46 @@ server {
         proxy_set_header Connection upgrade;
     }
 }
+
+# Support for code-server subdomain proxy
+# See https://github.com/cdr/code-server/blob/master/doc/FAQ.md#sub-domains
+# This example restricts access to ports 5000 through 5999 of the $upstream_app
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    
+    server_name ~^(?<subdomain>[5][0-9][0-9][0-9])\.code-server.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    # enable for ldap auth, fill in ldap details in ldap.conf
+    #include /config/nginx/ldap.conf;
+
+    # enable for Authelia
+    #include /config/nginx/authelia-server.conf;
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable the next two lines for ldap auth
+        #auth_request /auth;
+        #error_page 401 =200 /ldaplogin;
+
+        # enable for Authelia
+        #include /config/nginx/authelia-location.conf;
+
+        include /config/nginx/proxy.conf;
+        resolver 127.0.0.11 valid=30s;
+        set $upstream_app code-server;
+        set $upstream_proto http;
+        proxy_pass $upstream_proto://$upstream_app:$subdomain;
+
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection upgrade;
+        proxy_redirect http://$host https://$host;
+    }
+}


### PR DESCRIPTION
code-server supports proxying ports over a given subdomain.
This commit adds support in docker-letsencrypt.
See https://github.com/cdr/code-server/blob/master/doc/FAQ.md#sub-domains

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

